### PR TITLE
Fix version file URL properties

### DIFF
--- a/GameData/Yarbrough/Mk2Y/Mk2Y.version
+++ b/GameData/Yarbrough/Mk2Y/Mk2Y.version
@@ -1,6 +1,6 @@
 {
 	"NAME":"Yarbrough Mk2-Y Command Pod",
-	"URL":"https://raw.githubusercontent.com/zer0Kerbal/Mk2Y/Mk2-Y.version",
+	"URL":"https://github.com/zer0Kerbal/Mk2Y/raw/master/Mk2Y.version",
 	"DOWNLOAD":"https://github.com/zer0Kerbal/Mk2Y/releases/latest",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/Mk2Y/master/Mk2-YChangelog.cfg",
     "GITHUB":

--- a/Mk2Y.version
+++ b/Mk2Y.version
@@ -1,6 +1,6 @@
 {
 	"NAME":"Yarbrough Mk2-Y Command Pod",
-	"URL":"https://raw.githubusercontent.com/zer0Kerbal/Mk2Y/Mk2-Y.version",
+	"URL":"https://github.com/zer0Kerbal/Mk2Y/raw/master/Mk2Y.version",
 	"DOWNLOAD":"https://github.com/zer0Kerbal/Mk2Y/releases/latest",
 	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/zer0Kerbal/Mk2Y/master/Mk2-YChangelog.cfg",
     "GITHUB":


### PR DESCRIPTION
The current URL is a 404.
Now it's fixed.

Another tag for @zer0Kerbal because GitHub thinks pull requests are unimportant.